### PR TITLE
Added --log-file=- directive to default CMD

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,4 +7,4 @@ RUN pip install --no-cache-dir -r requirements.txt
 
 COPY . .
 
-CMD ["gunicorn", "--bind=0.0.0.0:8000", "tensorio_bundler.rest:api"]
+CMD ["gunicorn", "--bind=0.0.0.0:8000", "--log-file=-", "tensorio_bundler.rest:api"]


### PR DESCRIPTION
This ensures that gunicorn sends logs to stdout from the API process.